### PR TITLE
Allow bucket base dir in aws eb

### DIFF
--- a/lib/snap_deploy/provider/aws/elastic_beanstalk.rb
+++ b/lib/snap_deploy/provider/aws/elastic_beanstalk.rb
@@ -24,6 +24,10 @@ class SnapDeploy::Provider::AWS::ElasticBeanstalk < Clamp::Command
     'BUCKET_BASE_DIR',
     'S3 Bucket base directory'
 
+  option '--version',
+    'VERSION',
+    'Application Version'
+
   option '--region',
     "REGION",
     'EC2 Region.',
@@ -103,7 +107,7 @@ class SnapDeploy::Provider::AWS::ElasticBeanstalk < Clamp::Command
   end
 
   def version_label
-    "snap-ci-#{pipeline_counter}-#{short_commit}"
+    version ? version : "snap-ci-#{pipeline_counter}-#{short_commit}"
   end
 
   def create_bucket


### PR DESCRIPTION
- Be able to upload to an S3 to a different path than the root
