### PR TITLE
Added option to specify archive file to upload for EB

### DIFF
--- a/lib/snap_deploy/version.rb
+++ b/lib/snap_deploy/version.rb
@@ -1,3 +1,3 @@
 module SnapDeploy
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Can specify custom archive file which can be a build artifact to upload to AWS EB.

No spec file for the AWS EB and didn't add any new test. 

AWS Ruby client 2.0+ has a stub feature that we can use instead of using doubles but this has many breaking changes. 
https://ruby.awsblog.com/post/Tx15V81MLPR8D73/Client-Response-Stubs